### PR TITLE
fix: thread lifycycle mismatch

### DIFF
--- a/globals.c
+++ b/globals.c
@@ -39,8 +39,7 @@ static void wait_for_threads(struct globals_t* g)
 		pthread_mutex_unlock(&g->mutex);
 
 		if (num_threads > 0) {
-			pthread_kill(thread, SIGTERM);
-			pthread_join(thread, NULL);
+			pthread_cancel(thread);
 		}
 	} while (num_threads > 0);
 }

--- a/main.c
+++ b/main.c
@@ -157,7 +157,7 @@ static void main_loop(struct globals_t* g)
 	pthread_attr_t attr;
 	pthread_attr_init(&attr);
 	pthread_attr_setstacksize(&attr, 65536);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+	pthread_attr_setstacksize(&attr, 65536);
 
 	while (!g->terminate) {
 		const long int timeout = SESSION_TIMEOUT;


### PR DESCRIPTION
This pull request removes the setting of the thread's detach state to `PTHREAD_CREATE_DETACHED` when initializing thread attributes.

* Removed the call to `pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED)` in `main_loop`, so threads will no longer be created as detached by default.