### PR TITLE
fix: use `my_strdup()` instead of `strdup()`

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -8,8 +8,8 @@
 #include <pwd.h>
 #include <grp.h>
 #include <limits.h>
-#include "globals.h"
 #include "cmdline.h"
+#include "globals.h"
 
 static struct option long_options[] = {
 	{ "rsa-key",    required_argument, 0, 'r' },
@@ -208,7 +208,6 @@ static void handle_server_key(const char* keyfile, struct globals_t* g)
 		free(*loc);
 		*loc = my_strdup(keyfile);
 	}
-
 }
 
 void parse_options(int argc, char** argv, struct globals_t* g)
@@ -243,23 +242,23 @@ void parse_options(int argc, char** argv, struct globals_t* g)
 
 			case 'b':
 				free(g->bind_address);
-				g->bind_address = strdup(optarg);
+				g->bind_address = my_strdup(optarg);
 				break;
 
 			case 'p':
 				free(g->bind_port);
-				g->bind_port = strdup(optarg);
+				g->bind_port = my_strdup(optarg);
 				break;
 
 #ifndef MINIMALISTIC_BUILD
 			case 'P':
 				free(g->pid_file);
-				g->pid_file = strdup(optarg);
+				g->pid_file = my_strdup(optarg);
 				break;
 
 			case 'n':
 				free(g->daemon_name);
-				g->daemon_name = strdup(optarg);
+				g->daemon_name = my_strdup(optarg);
 				break;
 
 			case 'f':

--- a/cmdline.h
+++ b/cmdline.h
@@ -1,6 +1,7 @@
 #ifndef CMDLINE_H_
 #define CMDLINE_H_
 
+struct globals_t;
 void parse_options(int argc, char** argv, struct globals_t* g);
 
 #endif /* CMDLINE_H_ */


### PR DESCRIPTION
This pull request makes several improvements to memory management in the command-line parsing logic. The main changes involve replacing `strdup` with `my_strdup` for consistency and potentially improved error handling.

* Replaced all instances of `strdup` with `my_strdup` when assigning strings to members of the `globals_t` structure in the `parse_options` function and related code, ensuring consistent use of a custom string duplication function. [[1]](diffhunk://#diff-5a61a0388a316c63dbcd80f20b01eab21f762b9209265e4f8f5bf22ca98847c1L246-R262) [[2]](diffhunk://#diff-5a61a0388a316c63dbcd80f20b01eab21f762b9209265e4f8f5bf22ca98847c1L211)
