### PR TITLE
fix: address deprecations from libssh 0.12.0

### DIFF
--- a/main.c
+++ b/main.c
@@ -90,7 +90,14 @@ static void set_options(struct globals_t* g)
 #if LIBSSH_VERSION_INT >= SSH_VERSION_INT(0, 7, 90)
 	if (!g->rsa_key && !g->dsa_key && !g->ecdsa_key && !g->ed25519_key) {
 		ssh_key key;
-		int res = ssh_pki_generate(SSH_KEYTYPE_RSA, 2048, &key);
+		int res;
+
+#if LIBSSH_VERSION_INT >= SSH_VERSION_INT(0, 12, 0)
+		res = ssh_pki_generate_key(SSH_KEYTYPE_RSA, NULL, &key);
+#else
+		res = ssh_pki_generate(SSH_KEYTYPE_RSA, 0, &key);
+#endif
+
 		if (res == SSH_OK) {
 			ssh_bind_options_set(g->sshbind, SSH_BIND_OPTIONS_IMPORT_KEY, key);
 		}


### PR DESCRIPTION
This pull request updates the way RSA keys are generated for different versions of the libssh library in the `main.c` file. The change ensures compatibility with both newer and older versions of libssh by conditionally using the appropriate key-generation function.

libssh compatibility improvements:

* Updated the RSA key generation logic in the `set_options` function to use `ssh_pki_generate_key` for libssh versions 0.12.0 and above, and fall back to `ssh_pki_generate` for earlier versions. This ensures the code works correctly across multiple libssh versions.